### PR TITLE
Fixing typo in grunt config example

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -163,7 +163,7 @@ module.exports = function(grunt) {
       options: {
         processors: [
           require('autoprefixer-core')({ browsers: ['> 0%'] }).postcss, //Other plugin
-          require('postcss-custom-selector')(),
+          require('postcss-custom-selectors')(),
         ]
       },
       dist: {

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ module.exports = function(grunt) {
       options: {
         processors: [
           require('autoprefixer-core')({ browsers: ['> 0%'] }).postcss, //Other plugin
-          require('postcss-custom-selector')(),
+          require('postcss-custom-selectors')(),
         ]
       },
       dist: {


### PR DESCRIPTION
I was testing out your post-custom-selectors with grunt. I noticed a typo in grunt example config - just a missing "S" at the end of postcss-custom-selector. If left unnoticed, grunt task will fail though. I am sure all devs will figure it out, so my PR is just a matter of convenience. 