### PR TITLE
fixed typo in example gulp config

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ module.exports = function(grunt) {
 var gulp = require('gulp');
 var rename = require('gulp-rename');
 var postcss = require('gulp-postcss');
-var selector = require('postcss-custom-selector')
+var selector = require('postcss-custom-selectors')
 var autoprefixer = require('autoprefixer-core')
 
 gulp.task('default', function () {


### PR DESCRIPTION
run into this after copy-pasting some of the example config, just a missing 's'