### PR TITLE
Added additional syntax "@define-selector"

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function customSelector(options) {
 
     // 读取自定义选择器
     styles.eachAtRule(function(rule) {
-      if (rule.name !== "custom-selector") {
+      if (rule.name !== "custom-selector" && rule.name !== "define-selector") {
         return
       }
 


### PR DESCRIPTION
Added additional optional syntax "@define-selector" to match conventions
of other popular postcss plugins such as @define-mixin & @define-extend.