### PR TITLE
Split rules on whitespace, not only on spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function customSelector(options) {
         return
       }
 
-      var params = rule.params.split(" ")
+      var params = rule.params.split(/\s+/)
         // @custom-selector = @custom-selector <extension-name> <selector>
         // map[<extension-name>] = <selector>
 

--- a/test/fixtures/multiline.css
+++ b/test/fixtures/multiline.css
@@ -1,0 +1,7 @@
+@custom-selector :--multiline
+  .foo
+  ;
+
+:--multiline {
+  display: block;
+}

--- a/test/fixtures/multiline.expected.css
+++ b/test/fixtures/multiline.expected.css
@@ -1,0 +1,3 @@
+.foo {
+  display: block;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -21,6 +21,7 @@ function compareFixtures(t, name, msg, opts, postcssOpts) {
 test("@custom-selector", function(t) {
   compareFixtures(t, "heading", "should transform custom selector")
   compareFixtures(t, "pseudo", "should transform custom selector")
+  compareFixtures(t, "multiline", "should transform custom selector")
 
   compareFixtures(t, "extension", "local extensions", {
     extensions: {


### PR DESCRIPTION
This pull requests makes the parser a little bit more liberal with whitespace in the rule.

It allows you to write custom selectors like this:

``` css
@custom-selector :--buttons
    .MyElement-button,
    .MyOtherElement-button;
```

I do not think this is against the spec (I've seen nothing about these cases)