### PR TITLE
By matching anything after the custom selector we avoid a potential p…

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
  * :--foo
  * 注意：CSS 选择器区分大小写
  */
-//var re_CUSTOM_SELECTOR = /([^,]*?)(:-{2,}[\w-]+)([^,]*)/g
 var re_CUSTOM_SELECTOR = /([^,]*?)(:-{2,}[\w-]+)(.*)/g
 
 /**
@@ -53,13 +52,14 @@ function customSelector(options) {
     if (!options.lineBreak  && options.lineBreak == false) {
        line_break = ' '
     }
+
     // 转换自定义的选择器别名
     styles.eachRule(function(rule) {
       for (var prop in customSelectors) {
         if (rule.selector.indexOf(prop) >= 0) {
           customSelector = customSelectors[prop]
+          
           // $2 = <extension-name> （自定义的选择器名称）
-
           rule.selector = rule.selector.replace(re_CUSTOM_SELECTOR, function($0, $1, $2, $3) {
             if ($2 === prop) {
               return customSelector.split(",").map(function(selector) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@
  * :--foo
  * 注意：CSS 选择器区分大小写
  */
-var re_CUSTOM_SELECTOR = /([^,]*?)(:-{2,}[\w-]+)([^,]*)/g
+//var re_CUSTOM_SELECTOR = /([^,]*?)(:-{2,}[\w-]+)([^,]*)/g
+var re_CUSTOM_SELECTOR = /([^,]*?)(:-{2,}[\w-]+)(.*)/g
 
 /**
  * 暴露插件
@@ -52,7 +53,6 @@ function customSelector(options) {
     if (!options.lineBreak  && options.lineBreak == false) {
        line_break = ' '
     }
-
     // 转换自定义的选择器别名
     styles.eachRule(function(rule) {
       for (var prop in customSelectors) {

--- a/test/fixtures/matches.css
+++ b/test/fixtures/matches.css
@@ -1,0 +1,11 @@
+@custom-selector :--buttons button, .button;
+
+:--buttons:matches(:focus) {
+    border: red;
+    display: block;
+}
+
+:--buttons:matches(:focus, .is-focused) {
+    border: red;
+    display: block;
+}

--- a/test/fixtures/matches.expected.css
+++ b/test/fixtures/matches.expected.css
@@ -1,0 +1,11 @@
+button:matches(:focus),
+.button:matches(:focus) {
+    border: red;
+    display: block;
+}
+
+button:matches(:focus, .is-focused),
+.button:matches(:focus, .is-focused) {
+    border: red;
+    display: block;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,7 @@ test("@custom-selector", function(t) {
   compareFixtures(t, "pseudo", "should transform pseudo")
   compareFixtures(t, "multiline", "should transform multiline")
   compareFixtures(t, "some-hyphen-selector", "should transform some-hyphen-selector")
+  compareFixtures(t, "matches", "should transform matches selector")
 
   compareFixtures(t, "extension", "should transform local extensions", {
     extensions: {


### PR DESCRIPTION
…roblem with commas. We should trust postcss to not give us multiple selectors in its array

This just simply avoids the check for , on the last part of the regex. Postcss takes care of splitting the selectors  so we shouldn't worry.

I attempted a better solution, as this regex will reject some valid selectors the use of \w ignores unicode for example. This solution just ended up in a rabbit hole of regex as well. I think its better to land this patch then rewrite this to use the postcss-css ast when it lands.


