### PR TITLE
Add test to reproduce warnings

### DIFF
--- a/test/fixtures/similar-matches/input.css
+++ b/test/fixtures/similar-matches/input.css
@@ -1,0 +1,20 @@
+@custom-selector :--foo .foo;
+@custom-selector :--foo-bar .foo .bar;
+@custom-selector :--foo-baz .foo .baz;
+@custom-selector :--foo-bar-baz .foo .bar .baz;
+
+:--foo {
+    color: red;
+}
+
+:--foo-bar {
+    color: green;
+}
+
+:--foo-baz {
+    color: black;
+}
+
+:--foo-bar-baz {
+    color: blue;
+}

--- a/test/fixtures/similar-matches/output.css
+++ b/test/fixtures/similar-matches/output.css
@@ -1,0 +1,15 @@
+.foo {
+    color: red;
+}
+
+.foo .bar {
+    color: green;
+}
+
+.foo .baz {
+    color: black;
+}
+
+.foo .bar .baz {
+    color: blue;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -30,6 +30,7 @@ test("@custom-selector", function(t) {
   compareFixtures(t, "multiline", "should transform multiline")
   compareFixtures(t, "some-hyphen", "should transform some hyphen")
   compareFixtures(t, "matches", "should transform matches selector")
+  compareFixtures(t, "similar-matches", "should transform matches selector")
 
   compareFixtures(t, "extension", "should transform local extensions", {
     extensions: {


### PR DESCRIPTION
If I run this, I get warnings

```
$ npm test

> postcss-custom-selectors@2.1.0 test /Users/emmenko/dev/src/postcss-custom-selectors
> tape test

TAP version 13
# @custom-selector
ok 1 should transform heading
ok 2 should transform pseudo
ok 3 should transform multiline
ok 4 should transform some hyphen
ok 5 should transform matches selector
Warning: The selector ':--foo-bar' is undefined in CSS!
Warning: The selector ':--foo-baz' is undefined in CSS!
Warning: The selector ':--foo-bar-baz' is undefined in CSS!
Warning: The selector ':--foo-bar-baz' is undefined in CSS!
ok 6 should transform matches selector
ok 7 should transform local extensions

1..7
# tests 7
# pass  7

# ok
```

This is because of the way the selector is matched

```js
rule.selector.indexOf(prop)
```

So if I have following selectors

```css
@custom-selector :--foo .foo;
@custom-selector :--foo-bar .foo .bar;
@custom-selector :--foo-bar-baz .foo .bar .baz;
```

those are the matching results

```js
> ':--foo'.indexOf(':--foo')
0 // <---- ok
> ':--foo'.indexOf(':--foo-bar')
-1 // <---- ok
> ':--foo'.indexOf(':--foo-bar-baz')
-1 // <---- ok
> ':--foo-bar'.indexOf(':--foo')
0 // <---- WRONG
> ':--foo-bar'.indexOf(':--foo-bar')
0 // <---- ok
> ':--foo-bar'.indexOf(':--foo-bar-baz')
-1 // <---- ok
> ':--foo-bar-baz'.indexOf(':--foo')
0 // <---- WRONG
> ':--foo-bar-baz'.indexOf(':--foo-bar')
0 // <---- WRONG
> ':--foo-bar-baz'.indexOf(':--foo-bar-baz')
0 // <---- ok
```

---
How is this suppose to work? Should I use camelcase selectors instead (e.g.: `foo`, `fooBar`, `fooBarBaz`)? Or the matching should be fixed?

Thanks