### PR TITLE
Fixed: No more useless warnings for undefined non custom selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,42 @@
-# 2.1.0 - 2015-06-30
+# 2.2.0 - 2015-06-30
 
-* \- Fixed: the lineBreak option keeping the selectors indent [#18](https://github.com/postcss/postcss-custom-selectors/issues/18).
-* \- Fixed: the tip of an undefined selector [#20](https://github.com/postcss/postcss-custom-selectors/issues/20).
+* Fixed: No more useless warnings for undefined non custom selectors
+([#22](https://github.com/postcss/postcss-custom-selectors/issues/22))
+* Changed: warnings now use PostCSS message API
+
+# 2.1.1 - 2015-06-30
+
+* Fixed: the lineBreak option keeping the selectors indent
+([#18](https://github.com/postcss/postcss-custom-selectors/issues/18))
+* Fixed: the tip of an undefined selector
+([#20](https://github.com/postcss/postcss-custom-selectors/issues/20))
 
 # 2.1.0 - 2015-06-04
 
-* \- Fixed: use PostCSS 4.1 plugin API.
+* Changed: use PostCSS 4.1 plugin API
+([#13](https://github.com/postcss/postcss-custom-selectors/issues/13))
 
 # 2.0.1 - 2015-06-03
 
-* \- Fixed: `(foo, bar)` conversion error exists in the selector(See also [:matches() test](test/fixtures/matches/input.css)).
+* Fixed: `(foo, bar)` conversion error exists in the selector
+(See also [:matches() test](test/fixtures/matches/input.css))
 
 # 2.0.0 - 2015-05-29
 
-* \x Remove: no longer support `::` or `--` to defined a custom selectors, we must use the `:--` to defined it.
+* Removed: no longer support `::` or `--` to defined a custom selectors,
+you must use the syntax `:--` to define it.
+([#6](https://github.com/postcss/postcss-custom-selectors/issues/6))
+* Fixed: two or more consecutive hyphens in selector don't output `undefined`
+([#14](https://github.com/postcss/postcss-custom-selectors/issues/14))
 
-* \- Fixed: two or more consecutive hyphens in selector outputs is "undefined".
 
 # 1.1.1 - 2015-04-06
 
-* \- Fixed: add support for multilines definition
+* Fixed: add support for multilines definition
 
 # 1.1.0 - 2014-12-06
 
-* \- Added: "lineBreak" option
+* Added: "lineBreak" option
 
 # 1.0.0 - 2014-12-06
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-custom-selectors",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "PostCSS plugin to transform W3C CSS Extensions(Custom Selectors) to more compatible CSS",
   "keywords": [
     "css",

--- a/test/fixtures/similar-matches/input.css
+++ b/test/fixtures/similar-matches/input.css
@@ -12,3 +12,7 @@
 :--test p {
   display: block;
 }
+
+whatever {
+  display: block;
+}

--- a/test/fixtures/similar-matches/output.css
+++ b/test/fixtures/similar-matches/output.css
@@ -9,3 +9,7 @@ h4 h5 h6 {
 :--test p {
   display: block;
 }
+
+whatever {
+  display: block;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -13,15 +13,18 @@ function compareFixtures(t, name, msg, opts, postcssOpts) {
   //input
   postcssOpts.from = filename("fixtures/" + name + "/input")
   opts = opts || {}
-  var actual = postcss()
+  var result = postcss()
   .use(plugin(opts))
   .process(read(postcssOpts.from), postcssOpts)
-  .css
+
+  var actual = result.css
   //output
   var output = read(filename("fixtures/" + name + "/output"))
   //actual
   fs.writeFile(filename("fixtures/" + name + "/actual"), actual)
   t.equal(actual.trim(), output.trim(), msg)
+
+  return result
 }
 
 test("@custom-selector", function(t) {
@@ -30,10 +33,15 @@ test("@custom-selector", function(t) {
   compareFixtures(t, "multiline", "should transform multiline")
   compareFixtures(t, "some-hyphen", "should transform some hyphen")
   compareFixtures(t, "matches", "should transform matches selector")
-  compareFixtures(t, "similar-matches", "should transform matches selector")
+  var similarMatchesResult = compareFixtures(t, "similar-matches", "should transform matches selector")
+  t.ok(
+    similarMatchesResult.messages && similarMatchesResult.messages.length === 1,
+    "should add a message when a custom selectors is undefined"
+  )
+
   compareFixtures(t, "comment", "should transform comment")
   compareFixtures(t, "line-break", "should transform line break", {
-      lineBreak: false
+    lineBreak: false
   })
 
   compareFixtures(t, "extension", "should transform local extensions", {


### PR DESCRIPTION
Also:
- Changed: simpler message when a custom selector is undefined
- Changed: warnings now use PostCSS message API
- Some fixes in the Changelog + simpler formatting
- Added some references in the Changelog

Prepared as 2.2.0

Close #22