### PR TITLE
Fix bug importing from multiple sources

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -84,6 +84,14 @@ module.exports = {
 			expect: 'basic.import.expect.css',
 			result: 'basic.import.result.css'
 		},
+		'basic:import-css-from-multiple-files': {
+			message: 'supports { importFrom: ["test/empty.css", "test/import-selectors.css"] } usage',
+			options: {
+				importFrom: ["test/empty.css", "test/import-selectors.css"]
+			},
+			expect: 'basic.import.expect.css',
+			result: 'basic.import.result.css'
+		},
 		'basic:import-css-from-type': {
 			message: 'supports { importFrom: [ { from: "test/import-selectors.css", type: "css" } ] } usage',
 			options: {

--- a/lib/import-from.js
+++ b/lib/import-from.js
@@ -81,7 +81,8 @@ export default function importCustomSelectorsFromSources(sources) {
 		const type = (opts.type || path.extname(from).slice(1)).toLowerCase();
 
 		return { type, from };
-	}).reduce(async (customSelectors, source) => {
+	}).reduce(async (customSelectorsPromise, source) => {
+		const customSelectors = await customSelectorsPromise
 		const { type, from } = await source;
 
 		if (type === 'ast') {
@@ -101,7 +102,7 @@ export default function importCustomSelectorsFromSources(sources) {
 		}
 
 		return Object.assign(customSelectors, importCustomSelectorsFromObject(await source));
-	}, {});
+	}, Promise.resolve({}));
 }
 
 /* Helper utilities


### PR DESCRIPTION
This has been broken for some time.

After the first iteration the accumulator will be a promise (courtesy of `async`).