### PR TITLE
Object.assign issue with customSelectorsPromise

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ export default postcss.plugin('postcss-custom-selectors', opts => {
 
 	return async root => {
 		const customProperties = Object.assign(
+			{},
 			await customSelectorsPromise,
 			getCustomSelectors(root, { preserve })
 		);


### PR DESCRIPTION
Don't overwrite the result of the shared `customSelectorsPromise` when the plugin is used by multiple async postcss calls.