### PR TITLE
Support postcss 8

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -1,248 +1,246 @@
 module.exports = {
-	'postcss-custom-selectors': {
-		'basic': {
-			message: 'supports basic usage'
-		},
-		'basic:preserve': {
-			message: 'supports { preserve: true } usage',
-			options: {
-				preserve: true
+	'basic': {
+		message: 'supports basic usage'
+	},
+	'basic:preserve': {
+		message: 'supports { preserve: true } usage',
+		options: {
+			preserve: true
+		}
+	},
+	'safety': {
+		message: 'supports safe tag ordering (.foo:--h1 becomes h1.foo instead of .fooh1)'
+	},
+	'basic:import': {
+		message: 'supports { importFrom: { customSelectors: { ... } } } usage',
+		options: {
+			importFrom: {
+				customSelectors: {
+					':--heading': 'h1, h2, h3'
+				}
 			}
-		},
-		'safety': {
-			message: 'supports safe tag ordering (.foo:--h1 becomes h1.foo instead of .fooh1)'
-		},
-		'basic:import': {
-			message: 'supports { importFrom: { customSelectors: { ... } } } usage',
-			options: {
-				importFrom: {
+		}
+	},
+	'basic:import-fn': {
+		message: 'supports { importFrom() } usage',
+		options: {
+			importFrom() {
+				return {
 					customSelectors: {
 						':--heading': 'h1, h2, h3'
 					}
-				}
+				};
 			}
 		},
-		'basic:import-fn': {
-			message: 'supports { importFrom() } usage',
-			options: {
-				importFrom() {
-					return {
+		expect: 'basic.import.expect.css',
+		result: 'basic.import.result.css'
+	},
+	'basic:import-fn-promise': {
+		message: 'supports { async importFrom() } usage',
+		options: {
+			importFrom() {
+				return new Promise(resolve => {
+					resolve({
 						customSelectors: {
 							':--heading': 'h1, h2, h3'
 						}
-					};
-				}
-			},
-			expect: 'basic.import.expect.css',
-			result: 'basic.import.result.css'
-		},
-		'basic:import-fn-promise': {
-			message: 'supports { async importFrom() } usage',
-			options: {
-				importFrom() {
-					return new Promise(resolve => {
-						resolve({
-							customSelectors: {
-								':--heading': 'h1, h2, h3'
-							}
-						})
-					});
-				}
-			},
-			expect: 'basic.import.expect.css',
-			result: 'basic.import.result.css'
-		},
-		'basic:import-json': {
-			message: 'supports { importFrom: "test/import-selectors.json" } usage',
-			options: {
-				importFrom: 'test/import-selectors.json'
-			},
-			expect: 'basic.import.expect.css',
-			result: 'basic.import.result.css'
-		},
-		'basic:import-js': {
-			message: 'supports { importFrom: "test/import-selectors.js" } usage',
-			options: {
-				importFrom: 'test/import-selectors.js'
-			},
-			expect: 'basic.import.expect.css',
-			result: 'basic.import.result.css'
-		},
-		'basic:import-css': {
-			message: 'supports { importFrom: "test/import-selectors.css" } usage',
-			options: {
-				importFrom: 'test/import-selectors.css'
-			},
-			expect: 'basic.import.expect.css',
-			result: 'basic.import.result.css'
-		},
-		'basic:import-css-from': {
-			message: 'supports { importFrom: { from: "test/import-selectors.css" } } usage',
-			options: {
-				importFrom: { from: 'test/import-selectors.css' }
-			},
-			expect: 'basic.import.expect.css',
-			result: 'basic.import.result.css'
-		},
-		'basic:import-css-from-multiple-files': {
-			message: 'supports { importFrom: ["test/empty.css", "test/import-selectors.css"] } usage',
-			options: {
-				importFrom: ["test/empty.css", "test/import-selectors.css"]
-			},
-			expect: 'basic.import.expect.css',
-			result: 'basic.import.result.css'
-		},
-		'basic:import-css-from-type': {
-			message: 'supports { importFrom: [ { from: "test/import-selectors.css", type: "css" } ] } usage',
-			options: {
-				importFrom: [ { from: 'test/import-selectors.css', type: 'css' } ]
-			},
-			expect: 'basic.import.expect.css',
-			result: 'basic.import.result.css'
-		},
-		'basic:import-empty': {
-			message: 'supports { importFrom: {} } usage',
-			options: {
-				importFrom: {}
+					})
+				});
 			}
 		},
-		'basic:export': {
-			message: 'supports { exportTo: { customSelectors: { ... } } } usage',
-			options: {
-				exportTo: (global.__exportSelectorObject = global.__exportSelectorObject || {
-					customSelectors: null
-				})
-			},
-			expect: 'basic.expect.css',
-			result: 'basic.result.css',
-			after() {
-				if (__exportSelectorObject.customSelectors[':--foo'] !== '.foo') {
+		expect: 'basic.import.expect.css',
+		result: 'basic.import.result.css'
+	},
+	'basic:import-json': {
+		message: 'supports { importFrom: "test/import-selectors.json" } usage',
+		options: {
+			importFrom: 'test/import-selectors.json'
+		},
+		expect: 'basic.import.expect.css',
+		result: 'basic.import.result.css'
+	},
+	'basic:import-js': {
+		message: 'supports { importFrom: "test/import-selectors.js" } usage',
+		options: {
+			importFrom: 'test/import-selectors.js'
+		},
+		expect: 'basic.import.expect.css',
+		result: 'basic.import.result.css'
+	},
+	'basic:import-css': {
+		message: 'supports { importFrom: "test/import-selectors.css" } usage',
+		options: {
+			importFrom: 'test/import-selectors.css'
+		},
+		expect: 'basic.import.expect.css',
+		result: 'basic.import.result.css'
+	},
+	'basic:import-css-from': {
+		message: 'supports { importFrom: { from: "test/import-selectors.css" } } usage',
+		options: {
+			importFrom: { from: 'test/import-selectors.css' }
+		},
+		expect: 'basic.import.expect.css',
+		result: 'basic.import.result.css'
+	},
+	'basic:import-css-from-multiple-files': {
+		message: 'supports { importFrom: ["test/empty.css", "test/import-selectors.css"] } usage',
+		options: {
+			importFrom: ["test/empty.css", "test/import-selectors.css"]
+		},
+		expect: 'basic.import.expect.css',
+		result: 'basic.import.result.css'
+	},
+	'basic:import-css-from-type': {
+		message: 'supports { importFrom: [ { from: "test/import-selectors.css", type: "css" } ] } usage',
+		options: {
+			importFrom: [ { from: 'test/import-selectors.css', type: 'css' } ]
+		},
+		expect: 'basic.import.expect.css',
+		result: 'basic.import.result.css'
+	},
+	'basic:import-empty': {
+		message: 'supports { importFrom: {} } usage',
+		options: {
+			importFrom: {}
+		}
+	},
+	'basic:export': {
+		message: 'supports { exportTo: { customSelectors: { ... } } } usage',
+		options: {
+			exportTo: (global.__exportSelectorObject = global.__exportSelectorObject || {
+				customSelectors: null
+			})
+		},
+		expect: 'basic.expect.css',
+		result: 'basic.result.css',
+		after() {
+			if (__exportSelectorObject.customSelectors[':--foo'] !== '.foo') {
+				throw new Error('The exportTo function failed');
+			}
+		}
+	},
+	'basic:export-fn': {
+		message: 'supports { exportTo() } usage',
+		options: {
+			exportTo(customProperties) {
+				if (customProperties[':--foo'] !== '.foo') {
 					throw new Error('The exportTo function failed');
 				}
 			}
 		},
-		'basic:export-fn': {
-			message: 'supports { exportTo() } usage',
-			options: {
-				exportTo(customProperties) {
+		expect: 'basic.expect.css',
+		result: 'basic.result.css'
+	},
+	'basic:export-fn-promise': {
+		message: 'supports { async exportTo() } usage',
+		options: {
+			exportTo(customProperties) {
+				return new Promise((resolve, reject) => {
 					if (customProperties[':--foo'] !== '.foo') {
-						throw new Error('The exportTo function failed');
+						reject('The exportTo function failed');
+					} else {
+						resolve();
 					}
-				}
-			},
-			expect: 'basic.expect.css',
-			result: 'basic.result.css'
-		},
-		'basic:export-fn-promise': {
-			message: 'supports { async exportTo() } usage',
-			options: {
-				exportTo(customProperties) {
-					return new Promise((resolve, reject) => {
-						if (customProperties[':--foo'] !== '.foo') {
-							reject('The exportTo function failed');
-						} else {
-							resolve();
-						}
-					});
-				}
-			},
-			expect: 'basic.expect.css',
-			result: 'basic.result.css'
-		},
-		'basic:export-json': {
-			message: 'supports { exportTo: "test/export-selectors.json" } usage',
-			options: {
-				exportTo: 'test/export-selectors.json'
-			},
-			expect: 'basic.expect.css',
-			result: 'basic.result.css',
-			before() {
-				global.__exportSelectorsString = require('fs').readFileSync('test/export-selectors.json', 'utf8');
-			},
-			after() {
-				if (global.__exportSelectorsString !== require('fs').readFileSync('test/export-selectors.json', 'utf8')) {
-					throw new Error('The original file did not match the freshly exported copy');
-				}
+				});
 			}
 		},
-		'basic:export-js': {
-			message: 'supports { exportTo: "test/export-selectors.js" } usage',
-			options: {
-				exportTo: 'test/export-selectors.js'
-			},
-			expect: 'basic.expect.css',
-			result: 'basic.result.css',
-			before() {
-				global.__exportSelectorsString = require('fs').readFileSync('test/export-selectors.js', 'utf8');
-			},
-			after() {
-				if (global.__exportSelectorsString !== require('fs').readFileSync('test/export-selectors.js', 'utf8')) {
-					throw new Error('The original file did not match the freshly exported copy');
-				}
-			}
+		expect: 'basic.expect.css',
+		result: 'basic.result.css'
+	},
+	'basic:export-json': {
+		message: 'supports { exportTo: "test/export-selectors.json" } usage',
+		options: {
+			exportTo: 'test/export-selectors.json'
 		},
-		'basic:export-mjs': {
-			message: 'supports { exportTo: "test/export-selectors.mjs" } usage',
-			options: {
-				exportTo: 'test/export-selectors.mjs'
-			},
-			expect: 'basic.expect.css',
-			result: 'basic.result.css',
-			before() {
-				global.__exportSelectorsString = require('fs').readFileSync('test/export-selectors.mjs', 'utf8');
-			},
-			after() {
-				if (global.__exportSelectorsString !== require('fs').readFileSync('test/export-selectors.mjs', 'utf8')) {
-					throw new Error('The original file did not match the freshly exported copy');
-				}
-			}
+		expect: 'basic.expect.css',
+		result: 'basic.result.css',
+		before() {
+			global.__exportSelectorsString = require('fs').readFileSync('test/export-selectors.json', 'utf8');
 		},
-		'basic:export-css': {
-			message: 'supports { exportTo: "test/export-selectors.css" } usage',
-			options: {
-				exportTo: 'test/export-selectors.css'
-			},
-			expect: 'basic.expect.css',
-			result: 'basic.result.css',
-			before() {
-				global.__exportSelectorsString = require('fs').readFileSync('test/export-selectors.css', 'utf8');
-			},
-			after() {
-				if (global.__exportSelectorsString !== require('fs').readFileSync('test/export-selectors.css', 'utf8')) {
-					throw new Error('The original file did not match the freshly exported copy');
-				}
+		after() {
+			if (global.__exportSelectorsString !== require('fs').readFileSync('test/export-selectors.json', 'utf8')) {
+				throw new Error('The original file did not match the freshly exported copy');
 			}
+		}
+	},
+	'basic:export-js': {
+		message: 'supports { exportTo: "test/export-selectors.js" } usage',
+		options: {
+			exportTo: 'test/export-selectors.js'
 		},
-		'basic:export-css-to': {
-			message: 'supports { exportTo: { to: "test/export-selectors.css" } } usage',
-			options: {
-				exportTo: { to: 'test/export-selectors.css' }
-			},
-			expect: 'basic.expect.css',
-			result: 'basic.result.css',
-			before() {
-				global.__exportSelectorsString = require('fs').readFileSync('test/export-selectors.css', 'utf8');
-			},
-			after() {
-				if (global.__exportSelectorsString !== require('fs').readFileSync('test/export-selectors.css', 'utf8')) {
-					throw new Error('The original file did not match the freshly exported copy');
-				}
+		expect: 'basic.expect.css',
+		result: 'basic.result.css',
+		before() {
+			global.__exportSelectorsString = require('fs').readFileSync('test/export-selectors.js', 'utf8');
+		},
+		after() {
+			if (global.__exportSelectorsString !== require('fs').readFileSync('test/export-selectors.js', 'utf8')) {
+				throw new Error('The original file did not match the freshly exported copy');
 			}
+		}
+	},
+	'basic:export-mjs': {
+		message: 'supports { exportTo: "test/export-selectors.mjs" } usage',
+		options: {
+			exportTo: 'test/export-selectors.mjs'
 		},
-		'basic:export-css-to-type': {
-			message: 'supports { exportTo: { to: "test/export-selectors.css", type: "css" } } usage',
-			options: {
-				exportTo: { to: 'test/export-selectors.css', type: 'css' }
-			},
-			expect: 'basic.expect.css',
-			result: 'basic.result.css',
-			before() {
-				global.__exportSelectorsString = require('fs').readFileSync('test/export-selectors.css', 'utf8');
-			},
-			after() {
-				if (global.__exportSelectorsString !== require('fs').readFileSync('test/export-selectors.css', 'utf8')) {
-					throw new Error('The original file did not match the freshly exported copy');
-				}
+		expect: 'basic.expect.css',
+		result: 'basic.result.css',
+		before() {
+			global.__exportSelectorsString = require('fs').readFileSync('test/export-selectors.mjs', 'utf8');
+		},
+		after() {
+			if (global.__exportSelectorsString !== require('fs').readFileSync('test/export-selectors.mjs', 'utf8')) {
+				throw new Error('The original file did not match the freshly exported copy');
+			}
+		}
+	},
+	'basic:export-css': {
+		message: 'supports { exportTo: "test/export-selectors.css" } usage',
+		options: {
+			exportTo: 'test/export-selectors.css'
+		},
+		expect: 'basic.expect.css',
+		result: 'basic.result.css',
+		before() {
+			global.__exportSelectorsString = require('fs').readFileSync('test/export-selectors.css', 'utf8');
+		},
+		after() {
+			if (global.__exportSelectorsString !== require('fs').readFileSync('test/export-selectors.css', 'utf8')) {
+				throw new Error('The original file did not match the freshly exported copy');
+			}
+		}
+	},
+	'basic:export-css-to': {
+		message: 'supports { exportTo: { to: "test/export-selectors.css" } } usage',
+		options: {
+			exportTo: { to: 'test/export-selectors.css' }
+		},
+		expect: 'basic.expect.css',
+		result: 'basic.result.css',
+		before() {
+			global.__exportSelectorsString = require('fs').readFileSync('test/export-selectors.css', 'utf8');
+		},
+		after() {
+			if (global.__exportSelectorsString !== require('fs').readFileSync('test/export-selectors.css', 'utf8')) {
+				throw new Error('The original file did not match the freshly exported copy');
+			}
+		}
+	},
+	'basic:export-css-to-type': {
+		message: 'supports { exportTo: { to: "test/export-selectors.css", type: "css" } } usage',
+		options: {
+			exportTo: { to: 'test/export-selectors.css', type: 'css' }
+		},
+		expect: 'basic.expect.css',
+		result: 'basic.result.css',
+		before() {
+			global.__exportSelectorsString = require('fs').readFileSync('test/export-selectors.css', 'utf8');
+		},
+		after() {
+			if (global.__exportSelectorsString !== require('fs').readFileSync('test/export-selectors.css', 'utf8')) {
+				throw new Error('The original file did not match the freshly exported copy');
 			}
 		}
 	}

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: node_js
 
 node_js:
-  - 6
+  - 10
 
 install:
   - npm install --ignore-scripts

--- a/package.json
+++ b/package.json
@@ -27,10 +27,9 @@
     "test:tape": "postcss-tape"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "dependencies": {
-    "postcss": "^7.0.2",
     "postcss-selector-parser": "^5.0.0-rc.3"
   },
   "devDependencies": {
@@ -40,10 +39,14 @@
     "babel-eslint": "^9.0.0",
     "eslint": "^5.6.0",
     "eslint-config-dev": "^2.0.0",
-    "postcss-tape": "^2.2.0",
+    "postcss": "^8.1.2",
+    "postcss-tape": "^6.0.0",
     "pre-commit": "^1.2.2",
     "rollup": "^0.66.1",
     "rollup-plugin-babel": "^4.0.3"
+  },
+  "peerDependencies": {
+    "postcss": "^8.1.2"
   },
   "eslintConfig": {
     "extends": "dev",


### PR DESCRIPTION
Update plugin to support postcss 8, followed the migration guide available [here](https://evilmartians.com/chronicles/postcss-8-plugin-migration).

* update to postcss@8
* move "postcss" to peerDependencies
* updated plugin syntax
* update postcss-tape to latest
* update `.tape.js` config syntax
* drop node 6/8 support, updated "engines.node" field and travis.yml