### PR TITLE
Fix invalid spacing

### DIFF
--- a/lib/transform-selectors-by-custom-selectors.js
+++ b/lib/transform-selectors-by-custom-selectors.js
@@ -26,12 +26,13 @@ function transformSelector(selector, customSelectors) {
 			for (const replacementSelector of customSelectors[value].nodes) {
 				const selectorClone = selector.clone();
 
-				selectorClone.nodes.splice(index, 1, ...replacementSelector.clone().nodes.map(node => {
-					// use spacing from the current usage
-					node.spaces = { ...selector.nodes[index].spaces };
-
-					return node;
-				}));
+				const replacementSelectorNodes = replacementSelector.clone().nodes;
+				
+				// use spacing from the current usage
+				replacementSelectorNodes[0].spaces.before = selector.nodes[index].spaces.before;
+				replacementSelectorNodes[replacementSelectorNodes.length - 1].spaces.after = selector.nodes[index].spaces.after;
+				
+				selectorClone.nodes.splice(index, 1, ...replacementSelectorNodes);
 
 				const retranspiledSelectors = transformSelector(selectorClone, customSelectors);
 

--- a/test/basic.css
+++ b/test/basic.css
@@ -92,3 +92,7 @@ main :--foo + p {
 @custom-selector :--foobar .foo;
 
 :--foobar {}
+
+@custom-selector :--foobaz .foo.baz;
+
+a, :--foobaz {}

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -8,7 +8,7 @@ h1 + p,h2 + p,h3 + p,h4 + p,h5 + p,h6 + p {}
 .fizz > .foo,.buzz > .foo {}
 .btn-primary,.btn-success,.btn-info,.btn-warning,.btn-danger, .btn-primary:active, .btn-success:active, .btn-info:active, .btn-warning:active, .btn-danger:active {}
 
-.foo + p,.bar>.baz + p {
+.foo + p,.bar > .baz + p {
 	display: block;
 }
 
@@ -38,7 +38,7 @@ article :--heading + p {
 	margin-top: 0;
 }
 
-.foo,.bar>.baz {
+.foo,.bar > .baz {
 	display: block;
 }
 
@@ -55,3 +55,5 @@ main .foo + p {
 }
 
 .foo {}
+
+a, .foo.baz {}

--- a/test/basic.import-empty.expect.css
+++ b/test/basic.import-empty.expect.css
@@ -8,7 +8,7 @@ h1 + p,h2 + p,h3 + p,h4 + p,h5 + p,h6 + p {}
 .fizz > .foo,.buzz > .foo {}
 .btn-primary,.btn-success,.btn-info,.btn-warning,.btn-danger, .btn-primary:active, .btn-success:active, .btn-info:active, .btn-warning:active, .btn-danger:active {}
 
-.foo + p,.bar>.baz + p {
+.foo + p,.bar > .baz + p {
 	display: block;
 }
 
@@ -38,7 +38,7 @@ article :--heading + p {
 	margin-top: 0;
 }
 
-.foo,.bar>.baz {
+.foo,.bar > .baz {
 	display: block;
 }
 
@@ -55,3 +55,5 @@ main .foo + p {
 }
 
 .foo {}
+
+a, .foo.baz {}

--- a/test/basic.import.expect.css
+++ b/test/basic.import.expect.css
@@ -8,7 +8,7 @@ h1 + p,h2 + p,h3 + p,h4 + p,h5 + p,h6 + p {}
 .fizz > .foo,.buzz > .foo {}
 .btn-primary,.btn-success,.btn-info,.btn-warning,.btn-danger, .btn-primary:active, .btn-success:active, .btn-info:active, .btn-warning:active, .btn-danger:active {}
 
-.foo + p,.bar>.baz + p {
+.foo + p,.bar > .baz + p {
 	display: block;
 }
 
@@ -38,7 +38,7 @@ article h1 + p,article h2 + p,article h3 + p {
 	margin-top: 0;
 }
 
-.foo,.bar>.baz {
+.foo,.bar > .baz {
 	display: block;
 }
 
@@ -55,3 +55,5 @@ main .foo + p {
 }
 
 .foo {}
+
+a, .foo.baz {}

--- a/test/basic.preserve.expect.css
+++ b/test/basic.preserve.expect.css
@@ -37,7 +37,7 @@ h1 + p,h2 + p,h3 + p,h4 + p,h5 + p,h6 + p {}
 	.foo,
 	.bar > .baz;
 
-.foo + p,.bar>.baz + p {
+.foo + p,.bar > .baz + p {
 	display: block;
 }
 
@@ -106,7 +106,7 @@ article :--heading + p {
 	.foo,
 	.bar > .baz;
 
-.foo,.bar>.baz {
+.foo,.bar > .baz {
 	display: block;
 }
 
@@ -146,3 +146,9 @@ main :--foo + p {
 .foo {}
 
 :--foobar {}
+
+@custom-selector :--foobaz .foo.baz;
+
+a, .foo.baz {}
+
+a, :--foobaz {}

--- a/test/export-selectors.css
+++ b/test/export-selectors.css
@@ -18,3 +18,4 @@
 @custom-selector :--button button, .button;
 @custom-selector :--enter :hover, :focus;
 @custom-selector :--any-foobar .foo, .bar;
+@custom-selector :--foobaz .foo.baz;

--- a/test/export-selectors.js
+++ b/test/export-selectors.js
@@ -13,6 +13,7 @@ module.exports = {
 		':--multiline': '.foo,\n	.bar > .baz',
 		':--button': 'button, .button',
 		':--enter': ':hover, :focus',
-		':--any-foobar': '.foo, .bar'
+		':--any-foobar': '.foo, .bar',
+		':--foobaz': '.foo.baz'
 	}
 };

--- a/test/export-selectors.json
+++ b/test/export-selectors.json
@@ -13,6 +13,7 @@
     ":--multiline": ".foo,\n\t.bar > .baz",
     ":--button": "button, .button",
     ":--enter": ":hover, :focus",
-    ":--any-foobar": ".foo, .bar"
+    ":--any-foobar": ".foo, .bar",
+    ":--foobaz": ".foo.baz"
   }
 }

--- a/test/export-selectors.mjs
+++ b/test/export-selectors.mjs
@@ -12,5 +12,6 @@ export const customSelectors = {
 	':--multiline': '.foo,\n	.bar > .baz',
 	':--button': 'button, .button',
 	':--enter': ':hover, :focus',
-	':--any-foobar': '.foo, .bar'
+	':--any-foobar': '.foo, .bar',
+	':--foobaz': '.foo.baz'
 };


### PR DESCRIPTION
- solves #40
- adds a new test case from here: https://github.com/postcss/postcss-selector-parser/issues/157#issuecomment-431519835
- it no longer removes white space from `>` selectors, so most `*.expect.css` files needed updating